### PR TITLE
Add timestamp when listing content.

### DIFF
--- a/extensions_admin/pulp_ostree/extensions/admin/unit.py
+++ b/extensions_admin/pulp_ostree/extensions/admin/unit.py
@@ -57,6 +57,7 @@ class SearchCommand(DisplayUnitAssociationsCommand):
         'id',
         'created',
         'updated',
+        'timestamp',
         'remote_id',
         'digest',
         'refs'
@@ -76,6 +77,7 @@ class SearchCommand(DisplayUnitAssociationsCommand):
             'id': unit['id'],
             'created': unit['created'],
             'updated': unit['updated'],
+            'timestamp': metadata['timestamp'],
             'remote_id': metadata['remote_id'],
             'digest': metadata['digest'],
             'refs': metadata['refs']

--- a/extensions_admin/test/unit/admin/test_unit.py
+++ b/extensions_admin/test/unit/admin/test_unit.py
@@ -46,9 +46,10 @@ class TestSearchCommand(TestCase):
             'created': 1,
             'updated': 2,
             'metadata': {
-                'remote_id': 3,
-                'digest': 4,
-                'refs': 5
+                'timestamp': 3,
+                'remote_id': 4,
+                'digest': 5,
+                'refs': 6
             }
         }
 
@@ -62,9 +63,10 @@ class TestSearchCommand(TestCase):
                 'id': 0,
                 'created': 1,
                 'updated': 2,
-                'remote_id': 3,
-                'digest': 4,
-                'refs': 5
+                'timestamp': 3,
+                'remote_id': 4,
+                'digest': 5,
+                'refs': 6
             })
 
     @patch('pulp_ostree.extensions.admin.unit.SearchCommand.transform')


### PR DESCRIPTION
The _timestamp_ indicates when an ostree repository _snapshot_ (unit) was created as opposed to the _created_ or _updated_ fields which pertain to the unit association to the repository.
