### PR TITLE
Each unit is a branch head; Publish using pull-local.

### DIFF
--- a/common/pulp_ostree/common/constants.py
+++ b/common/pulp_ostree/common/constants.py
@@ -33,7 +33,5 @@ IMPORT_STEP_PULL = 'import_pull'
 IMPORT_STEP_ADD_UNITS = 'import_add_unit'
 
 PUBLISH_STEP_WEB_PUBLISHER = 'ostree_publish_step_web'
-PUBLISH_STEP_EMPTY = 'ostree_publish_empty'
-PUBLISH_STEP_CONTENT = 'ostree_publish_content'
-PUBLISH_STEP_METADATA = 'ostree_publish_metadata'
+PUBLISH_STEP_MAIN = 'ostree_publish_main'
 PUBLISH_STEP_OVER_HTTP = 'ostree_publish_over_http'

--- a/extensions_admin/pulp_ostree/extensions/admin/unit.py
+++ b/extensions_admin/pulp_ostree/extensions/admin/unit.py
@@ -14,7 +14,7 @@ def format_unit(unit_key):
     :rtype: str
     :see: pulp_ostree.common.model.Repository
     """
-    return 'remote_id: %(remote_id)s digest: %(digest)s' % unit_key
+    return 'remote_id:%(remote_id)s branch:%(branch)s commit:%(commit)s' % unit_key
 
 
 class CopyCommand(UnitCopyCommand):
@@ -57,10 +57,10 @@ class SearchCommand(DisplayUnitAssociationsCommand):
         'id',
         'created',
         'updated',
-        'timestamp',
         'remote_id',
-        'digest',
-        'refs'
+        'branch',
+        'commit',
+        'version'
     ]
 
     @staticmethod
@@ -77,10 +77,10 @@ class SearchCommand(DisplayUnitAssociationsCommand):
             'id': unit['id'],
             'created': unit['created'],
             'updated': unit['updated'],
-            'timestamp': metadata['timestamp'],
             'remote_id': metadata['remote_id'],
-            'digest': metadata['digest'],
-            'refs': metadata['refs']
+            'branch': metadata['branch'],
+            'commit': metadata['commit'],
+            'version': metadata.get('version', ''),
         }
         return document
 

--- a/extensions_admin/test/unit/admin/test_unit.py
+++ b/extensions_admin/test/unit/admin/test_unit.py
@@ -9,9 +9,13 @@ from pulp_ostree.extensions.admin.unit import format_unit, CopyCommand, RemoveCo
 class TestFunctions(TestCase):
 
     def test_format(self):
-        unit = dict(remote_id='test-id', digest='test-digest')
+        unit = dict(
+            remote_id='test-id',
+            branch='test-branch',
+            commit='test-commit'
+        )
         formatted = format_unit(unit)
-        self.assertEqual(formatted, 'remote_id: test-id digest: test-digest')
+        self.assertEqual(formatted, 'remote_id:test-id branch:test-branch commit:test-commit')
 
 
 class TestCopyCommand(TestCase):
@@ -46,10 +50,10 @@ class TestSearchCommand(TestCase):
             'created': 1,
             'updated': 2,
             'metadata': {
-                'timestamp': 3,
-                'remote_id': 4,
-                'digest': 5,
-                'refs': 6
+                'remote_id': 3,
+                'branch': 4,
+                'commit': 5,
+                'version': 6
             }
         }
 
@@ -63,10 +67,10 @@ class TestSearchCommand(TestCase):
                 'id': 0,
                 'created': 1,
                 'updated': 2,
-                'timestamp': 3,
-                'remote_id': 4,
-                'digest': 5,
-                'refs': 6
+                'remote_id': 3,
+                'branch': 4,
+                'commit': 5,
+                'version': 6
             })
 
     @patch('pulp_ostree.extensions.admin.unit.SearchCommand.transform')

--- a/plugins/pulp_ostree/plugins/distributors/steps.py
+++ b/plugins/pulp_ostree/plugins/distributors/steps.py
@@ -1,10 +1,11 @@
-from gettext import gettext as _
-import logging
 import os
-import ConfigParser
+import logging
 
+from gettext import gettext as _
+
+from pulp.plugins.util.misc import mkdir
 from pulp.plugins.util.publish_step import PluginStep, AtomicDirectoryPublishStep
-from pulp.common import constants as pulp_constants
+from pulp.common.constants import SORT_DIRECTION, SORT_ASCENDING
 from pulp.server.db.model.criteria import UnitAssociationCriteria
 
 from pulp_ostree.common import constants
@@ -21,142 +22,68 @@ class WebPublisher(PluginStep):
     of a repository via a web server
     """
 
-    def __init__(self, repo, publish_conduit, config):
+    def __init__(self, repo, conduit, config):
         """
         :param repo: Pulp managed Yum repository
         :type  repo: pulp.plugins.model.Repository
-        :param publish_conduit: Conduit providing access to relative Pulp functionality
-        :type  publish_conduit: pulp.plugins.conduits.repo_publish.RepoPublishConduit
+        :param conduit: Conduit providing access to relative Pulp functionality
+        :type  conduit: pulp.plugins.conduits.repo_publish.RepoPublishConduit
         :param config: Pulp configuration for the distributor
         :type  config: pulp.plugins.config.PluginCallConfiguration
         """
-        super(WebPublisher, self).__init__(constants.PUBLISH_STEP_WEB_PUBLISHER,
-                                           repo, publish_conduit, config)
+        super(WebPublisher, self).__init__(
+            constants.PUBLISH_STEP_WEB_PUBLISHER,
+            repo,
+            conduit,
+            config)
 
         publish_dir = configuration.get_web_publish_dir(repo, config)
         self.web_working_dir = os.path.join(self.get_working_dir(), repo.id)
         master_publish_dir = configuration.get_master_publish_dir(repo, config)
-        atomic_publish_step = AtomicDirectoryPublishStep(self.get_working_dir(),
-                                                         [(repo.id, publish_dir)],
-                                                         master_publish_dir,
-                                                         step_type=constants.PUBLISH_STEP_OVER_HTTP)
-        atomic_publish_step.description = _('Making files available via web.')
+        atomic_publish = AtomicDirectoryPublishStep(
+            self.get_working_dir(),
+            [(repo.id, publish_dir)],
+            master_publish_dir,
+            step_type=constants.PUBLISH_STEP_OVER_HTTP)
 
-        repo = self.get_repo()
-        if not repo.content_unit_counts:
-            self.add_child(CreateEmptyOSTreeStep())
-        else:
-            os.makedirs(self.web_working_dir)
-            content_step = PublishContentStep(working_dir=self.web_working_dir)
-            self.add_child(content_step)
-            self.add_child(PublishRefsStep(content_step, working_dir=self.web_working_dir))
+        atomic_publish.description = _('Making files available via web.')
 
-        self.add_child(atomic_publish_step)
+        main = MainStep()
+        self.add_child(main)
+        self.add_child(atomic_publish)
+        mkdir(self.web_working_dir)
 
 
-class CreateEmptyOSTreeStep(PluginStep):
-    """
-    Publish Metadata (refs, branch heads, etc)
-    """
+class MainStep(PluginStep):
 
-    def __init__(self):
-        super(CreateEmptyOSTreeStep, self).__init__(constants.PUBLISH_STEP_EMPTY)
+    def __init__(self, **kwargs):
+        super(MainStep, self).__init__(constants.PUBLISH_STEP_MAIN, **kwargs)
         self.context = None
         self.redirect_context = None
-        self.description = _('Publishing an empty OSTree.')
+        self.description = _('Publish Trees')
 
     def process_main(self):
         """
         create a blank ostree
         """
         repo = self.get_repo()
-        repo_path = os.path.join(self.get_working_dir(), repo.id)
-        ostree_repo = lib.Repository(repo_path)
+        path = os.path.join(self.get_working_dir(), repo.id)
+        ostree_repo = lib.Repository(path)
         ostree_repo.create()
-
-
-class PublishContentStep(PluginStep):
-    """
-    Publish Content
-    """
-
-    def __init__(self, **kwargs):
-        super(PublishContentStep, self).__init__(constants.PUBLISH_STEP_CONTENT, **kwargs)
-        self.context = None
-        self.redirect_context = None
-        self.description = _('Publishing OSTree Content.')
-        self.unit = None
-
-    def process_main(self):
-        """
-        Publish all the ostree files themselves
-        """
-        # Symlink all sub directories of the storage dir except the refs directory
-        self.unit = self._get_ostree_unit()
-        storage_path = self.unit.storage_path
-        blocked_dirs = ['refs']
-        directory_entries = os.listdir(storage_path)
-        working_dir = self.get_working_dir()
-        for entry in directory_entries:
-            source_dir = os.path.join(storage_path, entry)
-            if os.path.isdir(source_dir) and entry not in blocked_dirs:
-                target_dir = os.path.join(working_dir, entry)
-                os.symlink(source_dir, target_dir)
-
-    def _get_ostree_unit(self):
-        """
-        Get the ostree unit that was added the most recently
-
-        :returns: The ostree unit to use for publishing content & metadata
-        :rtype: pulp.plugins.model.AssociatedUnit
-        """
-        sort_direction = pulp_constants.SORT_DIRECTION[pulp_constants.SORT_DESCENDING]
-        criteria = UnitAssociationCriteria(type_ids=[constants.OSTREE_TYPE_ID],
-                                           unit_sort=[('created', sort_direction)])
+        criteria = UnitAssociationCriteria(
+            type_ids=[constants.OSTREE_TYPE_ID],
+            unit_sort=[('created', SORT_DIRECTION[SORT_ASCENDING])])
         units = self.get_conduit().get_units(criteria, as_generator=True)
         for unit in units:
-            return unit
+            branch = unit.unit_key['branch']
+            commit = unit.unit_key['commit']
+            ostree_repo.pull_local(unit.storage_path, [commit])
+            MainStep._add_ref(path, branch, commit)
 
-        # Should not be able to get here since an empty tree will use the CreateEmptyOSTreeStep
-        raise Exception(_('Unable to find OSTree unit'))
-
-
-class PublishRefsStep(PluginStep):
-    """
-    Publish refs, branch heads, etc
-    """
-
-    def __init__(self, content_step, **kwargs):
-        super(PublishRefsStep, self).__init__(constants.PUBLISH_STEP_METADATA, **kwargs)
-        self.context = None
-        self.redirect_context = None
-        self.content_step = content_step
-        self.description = _('Publishing OSTree Refs.')
-
-    def process_main(self):
-        """
-        Publish all the ostree metadata or create a blank ostree if this has never been synced
-        """
-        # make the remotes dir
-        refs_dir = os.path.join(self.get_working_dir(), 'refs')
-        os.makedirs(os.path.join(refs_dir, 'remotes'))
-
-        refs = self.content_step.unit.metadata['refs']
-
-        # publish all the heads
-        for head in refs['heads']:
-            file_path = os.path.join(refs_dir, head['path'])
-            if not os.path.exists(os.path.dirname(file_path)):
-                os.makedirs(os.path.dirname(file_path))
-                with open(file_path, "w") as f:
-                    f.write(head['commit_id'])
-
-        # copy the general config file
-        # clear out the remote section of the config file for the published copy
-        parser = ConfigParser.SafeConfigParser()
-        parser.read(os.path.join(self.content_step.unit.storage_path, 'config'))
-        for section in parser.sections():
-            if section.startswith('remote'):
-                parser.remove_section(section)
-        with open(os.path.join(self.get_working_dir(), 'config'), 'w') as new_config:
-            parser.write(new_config)
+    @staticmethod
+    def _add_ref(path, branch, commit):
+        path = os.path.join(path, 'refs', 'heads', os.path.dirname(branch))
+        mkdir(path)
+        path = os.path.join(path, os.path.basename(branch))
+        with open(path, 'w+') as fp:
+            fp.write(commit)

--- a/plugins/types/ostree.json
+++ b/plugins/types/ostree.json
@@ -3,7 +3,7 @@
         "id": "ostree",
         "display_name": "OSTree Branch",
         "description": "An OSTree branch",
-        "unit_key": ["remote_id", "digest"],
+        "unit_key": ["remote_id", "branch", "commit"],
         "search_indexes": []
     }
 ]}


### PR DESCRIPTION
https://pulp.plan.io/issues/95

Content unit model changed so that each unit is a branch head instead of a snapshot of the entire repository.  Publishing changed to create a new repository and instead of creating links to files in the *backing* ostree repository, pull-local is used to populate the published repository with only those objects referenced by the branch head commits.  Last, the commit metadata is included which *may* contains fields such as *version* depending on how the trees are composed.