### PR TITLE
refs:855 - store created ISODate used for sorting during publishing.

### DIFF
--- a/common/pulp_ostree/common/model.py
+++ b/common/pulp_ostree/common/model.py
@@ -6,6 +6,7 @@ The content model:
 
 import os
 
+from datetime import datetime
 from hashlib import sha256
 
 from pulp_ostree.common import constants
@@ -108,6 +109,21 @@ class Unit(Head):
     TYPE_ID = constants.OSTREE_TYPE_ID
 
     COMMIT = 'commit'
+    CREATED = '_created'
+
+    def __init__(self, remote_id, branch, commit, created=None):
+        """
+        :param remote_id: Uniquely identifies a *remote* OSTree repository.
+        :type remote_id: str
+        :param branch: The branch path.
+        :type branch: str
+        :param commit: A commit.
+        :type commit: Commit
+        :param created: The created (UTC) timestamp.
+        :type created: datetime
+        """
+        super(Unit, self).__init__(remote_id, branch, commit)
+        self.created = created or datetime.utcnow()
 
     @property
     def key(self):
@@ -131,4 +147,7 @@ class Unit(Head):
         :return: The commit metadata.
         :rtype: dict
         """
-        return self.commit.metadata
+        md = {}
+        md.update(self.commit.metadata)
+        md[Unit.CREATED] = self.created
+        return md

--- a/common/test/unit/common/test_model.py
+++ b/common/test/unit/common/test_model.py
@@ -63,6 +63,31 @@ class TestHeads(TestCase):
 
 class TestUnit(TestCase):
 
+    def test_init(self):
+        created = 1234
+        remote_id = '1234'
+        branch = '/branch/core'
+        commit = Mock()
+        unit = Unit(remote_id, branch, commit, created)
+        self.assertEqual(unit.remote_id, remote_id)
+        self.assertEqual(unit.branch, branch)
+        self.assertEqual(unit.commit, commit)
+        self.assertEqual(unit.created, created)
+
+    @patch('pulp_ostree.common.model.datetime')
+    def test_init_now(self, dt):
+        now = 1234
+        dt.utcnow.return_value = now
+        remote_id = '1234'
+        branch = '/branch/core'
+        commit = Mock()
+        unit = Unit(remote_id, branch, commit)
+        dt.utcnow.assert_called_once_with()
+        self.assertEqual(unit.remote_id, remote_id)
+        self.assertEqual(unit.branch, branch)
+        self.assertEqual(unit.commit, commit)
+        self.assertEqual(unit.created, now)
+
     def test_unit_key(self):
         remote_id = '1234'
         branch = '/branch/core'
@@ -77,8 +102,11 @@ class TestUnit(TestCase):
             })
 
     def test_unit_md(self):
+        created = 1234
         remote_id = '1234'
         branch = '/branch/core'
-        commit = Mock()
-        unit = Unit(remote_id, branch, commit)
-        self.assertEqual(unit.metadata, unit.commit.metadata)
+        commit = Mock(metadata={'version': '1.0'})
+        unit = Unit(remote_id, branch, commit, created=created)
+        md = {Unit.CREATED: created}
+        md.update(unit.commit.metadata)
+        self.assertEqual(unit.metadata, md)

--- a/plugins/pulp_ostree/plugins/distributors/steps.py
+++ b/plugins/pulp_ostree/plugins/distributors/steps.py
@@ -91,7 +91,7 @@ class MainStep(PluginStep):
         conduit = self.get_conduit()
         criteria = UnitAssociationCriteria(
             type_ids=[constants.OSTREE_TYPE_ID],
-            unit_sort=[('_id', SORT_DIRECTION[SORT_ASCENDING])])
+            unit_sort=[('_created', SORT_DIRECTION[SORT_ASCENDING])])
         for unit in conduit.get_units(criteria, as_generator=True):
             branch = unit.unit_key['branch']
             units[branch] = unit

--- a/plugins/test/unit/plugins/distributors/test_steps.py
+++ b/plugins/test/unit/plugins/distributors/test_steps.py
@@ -114,7 +114,7 @@ class TestMainStep(unittest.TestCase):
 
         # validation
         criteria.assert_called_once_with(
-            unit_sort=[('_id', pulp_constants.SORT_DIRECTION[pulp_constants.SORT_ASCENDING])],
+            unit_sort=[('_created', pulp_constants.SORT_DIRECTION[pulp_constants.SORT_ASCENDING])],
             type_ids=[constants.OSTREE_TYPE_ID])
         conduit.get_units.assert_called_once_with(criteria.return_value, as_generator=True)
         self.assertEqual(sorted(_units), sorted([units[1], units[-2], units[-1]]))


### PR DESCRIPTION
https://pulp.plan.io/issues/855

Store 'created' ISODate on OSTree units.  This is used to sort units for published.  We only want to publish the newest branch version of each branch.  The _id on content units is just a plain UUID and cannot be used for sorting.