### PR TITLE
Add support for ssl and gpg options.

### DIFF
--- a/common/pulp_ostree/common/constants.py
+++ b/common/pulp_ostree/common/constants.py
@@ -20,6 +20,7 @@ CLI_WEB_DISTRIBUTOR_ID = 'ostree_web_distributor_name_cli'
 
 # Configuration
 IMPORTER_CONFIG_KEY_BRANCHES = 'branches'
+IMPORTER_CONFIG_KEY_GPG_KEYS = 'gpg_keys'
 IMPORTER_CONFIG_FILE_PATH = 'server/plugins.conf.d/ostree_importer.json'
 DISTRIBUTOR_CONFIG_KEY_PUBLISH_DIRECTORY = 'ostree_publish_directory'
 DISTRIBUTOR_CONFIG_VALUE_PUBLISH_DIRECTORY = '/var/lib/pulp/published/ostree'
@@ -32,6 +33,7 @@ IMPORT_STEP_MAIN = 'import_main'
 IMPORT_STEP_CREATE_REPOSITORY = 'import_create_repository'
 IMPORT_STEP_PULL = 'import_pull'
 IMPORT_STEP_ADD_UNITS = 'import_add_unit'
+IMPORT_STEP_CLEAN = 'import_clean'
 
 PUBLISH_STEP_WEB_PUBLISHER = 'ostree_publish_step_web'
 PUBLISH_STEP_MAIN = 'ostree_publish_main'

--- a/common/pulp_ostree/common/errors.py
+++ b/common/pulp_ostree/common/errors.py
@@ -10,3 +10,7 @@ OST0001 = Error('OST0001',
 OST0002 = Error('OST0002',
                 _('Pulling remote branch: %(branch)s failed.  Reason: %(reason)s'),
                 ['branch', 'reason'])
+
+OST0003 = Error('OST0003',
+                _('Delete remote: %(id)s failed.  Reason: %(reason)s'),
+                ['id', 'reason'])

--- a/plugins/pulp_ostree/plugins/distributors/steps.py
+++ b/plugins/pulp_ostree/plugins/distributors/steps.py
@@ -79,6 +79,8 @@ class MainStep(PluginStep):
             commit = unit.unit_key['commit']
             ostree_repo.pull_local(unit.storage_path, [commit])
             MainStep._add_ref(path, branch, commit)
+        summary = lib.Summary(ostree_repo)
+        summary.generate()
 
     def _get_units(self):
         """

--- a/plugins/pulp_ostree/plugins/importers/steps.py
+++ b/plugins/pulp_ostree/plugins/importers/steps.py
@@ -4,6 +4,8 @@ import errno
 from gettext import gettext as _
 from logging import getLogger
 
+from gnupg import GPG
+
 from pulp.common.plugins import importer_constants
 from pulp.plugins.util.publish_step import PluginStep
 from pulp.plugins.model import Unit
@@ -34,41 +36,20 @@ class Main(PluginStep):
         self.remote_id = model.generate_remote_id(self.feed_url)
         self.storage_path = os.path.join(
             constants.SHARED_STORAGE, self.remote_id, constants.CONTENT_DIR)
+        self.repo_id = self.get_repo().id
         self.add_child(Create())
         self.add_child(Pull())
         self.add_child(Add())
+        self.add_child(Clean())
 
 
 class Create(PluginStep):
     """
     Ensure the local ostree repository has been created
-    and the configured.
+    and the configured.  A temporary remote is created using the repo_id as
+    the remote_id.  The remote is created using the Remote which stores SSL
+    certificates in the working directory.
     """
-
-    @staticmethod
-    def _init_repository(path, remote_id, url):
-        """
-        Ensure the local ostree repository has been created
-        and the configured.
-
-        :param path: The absolute path to the local repository.
-        :type path: str
-        :param remote_id: The remote ID.
-        :type remote_id: str
-        :param url: The URL to the remote repository.
-        :type url: str
-        :raises PulpCodedException:
-        """
-        try:
-            repository = lib.Repository(path)
-            try:
-                repository.open()
-            except lib.LibError:
-                repository.create()
-                repository.add_remote(remote_id, url)
-        except lib.LibError, le:
-            pe = PulpCodedException(errors.OST0001, path=path, reason=str(le))
-            raise pe
 
     def __init__(self):
         super(Create, self).__init__(step_type=constants.IMPORT_STEP_CREATE_REPOSITORY)
@@ -82,11 +63,32 @@ class Create(PluginStep):
         :raises PulpCodedException:
         """
         path = self.parent.storage_path
-        remote_id = self.parent.remote_id
-        url = self.parent.feed_url
+
         mkdir(path)
         mkdir(os.path.join(os.path.dirname(path), constants.LINKS_DIR))
-        self._init_repository(path, remote_id, url)
+        self._init_repository(path)
+
+    def _init_repository(self, path):
+        """
+        Ensure the local ostree repository has been created
+        and the configured.  Also creates and configures a temporary remote
+        used for the subsequent pulls.
+
+        :param path: The absolute path to the local repository.
+        :type path: str
+        :raises PulpCodedException:
+        """
+        try:
+            repository = lib.Repository(path)
+            try:
+                repository.open()
+            except lib.LibError:
+                repository.create()
+            remote = Remote(self, repository)
+            remote.add()
+        except lib.LibError, le:
+            pe = PulpCodedException(errors.OST0001, path=path, reason=str(le))
+            raise pe
 
 
 class Pull(PluginStep):
@@ -100,12 +102,13 @@ class Pull(PluginStep):
 
     def process_main(self):
         """
-        Pull each of the specified branches.
+        Pull each of the specified branches using the temporary remote
+        configured using the repo_id as the remote_id.
 
         :raises PulpCodedException:
         """
         for branch_id in self.parent.branches:
-            self._pull(self.parent.storage_path, self.parent.remote_id, branch_id)
+            self._pull(self.parent.storage_path, self.parent.repo_id, branch_id)
 
     def _pull(self, path, remote_id, branch_id):
         """
@@ -180,3 +183,206 @@ class Add(PluginStep):
                 pass  # identical
             else:
                 raise
+
+
+class Clean(PluginStep):
+    """
+    Clean up after import.
+    """
+
+    def __init__(self):
+        super(Clean, self).__init__(step_type=constants.IMPORT_STEP_CLEAN)
+        self.description = _('Clean')
+
+    def process_main(self):
+        """
+        Clean up after import:
+         - Delete the remote used for the pull.
+        """
+        path = self.parent.storage_path
+        remote_id = self.parent.repo_id
+        try:
+            repository = lib.Repository(path)
+            remote = lib.Remote(remote_id, repository)
+            remote.delete()
+        except lib.LibError, le:
+            pe = PulpCodedException(errors.OST0003, id=remote_id, reason=str(le))
+            raise pe
+
+
+class Remote(object):
+    """
+    Represents an OSTree remote.
+    Used to build and configure an OSTree remote.
+    The complexity of configuring the remote based on the importer
+    configuration is isolated here.
+
+    :ivar step: The create step.
+    :type step: Create
+    :ivar repository: An OSTree repository.
+    :type repository: lib.Repository
+    """
+
+    def __init__(self, step, repository):
+        """
+        :param step: The create step.
+        :type step: Create
+        :param repository: An OSTree repository.
+        :type repository: lib.Repository
+        """
+        self.step = step
+        self.repository = repository
+
+    @property
+    def url(self):
+        """
+        The remote URL.
+
+        :return: The remote URL
+        :rtype: str
+        """
+        return self.step.parent.feed_url
+
+    @property
+    def remote_id(self):
+        """
+        The remote ID.
+
+        :return: The remote ID.
+        :rtype: str
+        """
+        return self.step.parent.repo_id
+
+    @property
+    def working_dir(self):
+        """
+        The working directory.
+
+        :return: The absolute path to the working directory.
+        :rtype: str
+        """
+        return self.step.get_working_dir()
+
+    @property
+    def config(self):
+        """
+        The importer configuration.
+
+        :return: The importer configuration.
+        :rtype: pulp.server.plugins.config.PluginCallConfiguration
+        """
+        return self.step.get_config()
+
+    @property
+    def ssl_key_path(self):
+        """
+        The SSL private key path.
+
+        :return: The absolute path to the private key.
+        :rtype: str
+        """
+        path = None
+        key = self.config.get(importer_constants.KEY_SSL_CLIENT_KEY)
+        if key:
+            path = os.path.join(self.working_dir, 'key.pem')
+            with open(path, 'w+') as fp:
+                fp.write(key)
+            os.chmod(path, 0600)
+        return path
+
+    @property
+    def ssl_cert_path(self):
+        """
+        The SSL client certificate key path.
+
+        :return: The absolute path to the client certificate.
+        :rtype: str
+        """
+        path = None
+        key = self.config.get(importer_constants.KEY_SSL_CLIENT_CERT)
+        if key:
+            path = os.path.join(self.working_dir, 'cert.pem')
+            with open(path, 'w+') as fp:
+                fp.write(key)
+        return path
+
+    @property
+    def ssl_ca_path(self):
+        """
+        The SSL CA certificate key path.
+
+        :return: The absolute path to the CA certificate.
+        :rtype: str
+        """
+        path = None
+        key = self.config.get(importer_constants.KEY_SSL_CA_CERT)
+        if key:
+            path = os.path.join(self.working_dir, 'ca.pem')
+            with open(path, 'w+') as fp:
+                fp.write(key)
+        return path
+
+    @property
+    def ssl_validation(self):
+        """
+        The SSL validation flag.
+
+        :return: True if SSL validation is enabled.
+        :rtype: bool
+        """
+        return self.config.get(importer_constants.KEY_SSL_VALIDATION, False)
+
+    @property
+    def gpg_keys(self):
+        """
+        The GPG keyring path and list of key IDs.
+
+        :return: A tuple of: (path, key_ids)
+            The *path* is the absolute path to a keyring.
+            The *key_ids* is a list of key IDs added to the keyring.
+        :rtype: tuple
+        """
+        home = self.working_dir
+        path = os.path.join(home, 'pubring.gpg')
+        key_list = self.config.get(constants.IMPORTER_CONFIG_KEY_GPG_KEYS, [])
+        gpg = GPG(gnupghome=home)
+        map(gpg.import_keys, key_list)
+        key_ids = [key['keyid'] for key in gpg.list_keys()]
+        return path, key_ids
+
+    @property
+    def proxy_url(self):
+        """
+        The proxy URL.
+
+        :return: The proxy URL.
+        :rtype: str
+        """
+        url = None
+        host = self.config.get(importer_constants.KEY_PROXY_HOST)
+        port = self.config.get(importer_constants.KEY_PROXY_PORT)
+        user = self.config.get(importer_constants.KEY_PROXY_USER)
+        password = self.config.get(importer_constants.KEY_PROXY_PASS)
+        if host and port:
+            url = ':'.join((host, str(port)))
+            if user and password:
+                auth = ':'.join((user, password))
+                url = '@'.join((auth, url))
+        return url
+
+    def add(self):
+        """
+        Add (or replace) this remote to the repository.
+        """
+        path, key_ids = self.gpg_keys
+        impl = lib.Remote(self.remote_id, self.repository)
+        impl.url = self.url
+        impl.ssl_key_path = self.ssl_key_path
+        impl.ssl_cert_path = self.ssl_cert_path
+        impl.ssl_ca_path = self.ssl_ca_path
+        impl.ssl_validation = self.ssl_validation
+        impl.gpg_validation = len(key_ids) > 0
+        impl.proxy_url = self.proxy_url
+        impl.update()
+        if key_ids:
+            impl.import_key(path, key_ids)

--- a/plugins/test/unit/plugins/distributors/test_steps.py
+++ b/plugins/test/unit/plugins/distributors/test_steps.py
@@ -91,6 +91,8 @@ class TestMainStep(unittest.TestCase):
                 ((path, units[0].unit_key['branch'], units[0].unit_key['commit']), {}),
                 ((path, units[1].unit_key['branch'], units[1].unit_key['commit']), {}),
             ])
+        lib.Summary.assert_called_once_with(ostree_repo)
+        lib.Summary.return_value.generate.assert_called_once_with()
 
     @patch('pulp_ostree.plugins.distributors.steps.UnitAssociationCriteria')
     def test_get_units(self, criteria):

--- a/plugins/test/unit/plugins/importers/test_steps.py
+++ b/plugins/test/unit/plugins/importers/test_steps.py
@@ -3,15 +3,19 @@ import errno
 
 from unittest import TestCase
 
-from mock import patch, Mock, ANY
+from mock import patch, Mock, PropertyMock, ANY
 
 from pulp.common.plugins import importer_constants
 from pulp.server.exceptions import PulpCodedException
 
 from pulp_ostree.plugins.lib import LibError
-from pulp_ostree.plugins.importers.steps import Main, Create, Pull, Add
+from pulp_ostree.plugins.importers.steps import Main, Create, Pull, Add, Clean, Remote
 from pulp_ostree.common.model import Unit
 from pulp_ostree.common import constants, errors
+
+
+# The module being tested
+MODULE = 'pulp_ostree.plugins.importers.steps'
 
 
 class TestMainStep(TestCase):
@@ -46,61 +50,75 @@ class TestMainStep(TestCase):
         self.assertEqual(step.storage_path,
                          os.path.join(constants.SHARED_STORAGE, digest, 'content'))
 
-        self.assertEqual(len(step.children), 3)
+        self.assertEqual(len(step.children), 4)
         self.assertTrue(isinstance(step.children[0], Create))
         self.assertTrue(isinstance(step.children[1], Pull))
         self.assertTrue(isinstance(step.children[2], Add))
+        self.assertTrue(isinstance(step.children[3], Clean))
 
 
 class TestCreate(TestCase):
-
-    @patch('pulp_ostree.plugins.importers.steps.lib')
-    def test_init_repository(self, fake_lib):
-        url = 'url-123'
-        remote_id = 'remote-123'
-        path = 'root/path-123'
-
-        fake_lib.LibError = LibError
-        fake_lib.Repository.return_value.open.side_effect = LibError
-
-        # test
-        Create._init_repository(path, remote_id, url)
-
-        # validation
-        fake_lib.Repository.assert_called_once_with(path)
-        fake_lib.Repository.return_value.create.assert_called_once_with()
-        fake_lib.Repository.return_value.add_remote.assert_called_once_with(remote_id, url)
-
-    @patch('pulp_ostree.plugins.importers.steps.lib')
-    def test_init_repository_exists(self, fake_lib):
-        url = 'url-123'
-        remote_id = 'remote-123'
-        path = 'root/path-123'
-
-        # test
-        Create._init_repository(path, remote_id, url)
-
-        # validation
-        fake_lib.Repository.assert_called_once_with(path)
-        fake_lib.Repository.return_value.open.assert_called_once_with()
-        self.assertFalse(fake_lib.Repository.return_value.add_remote.called)
-
-    @patch('pulp_ostree.plugins.importers.steps.lib')
-    def test_init_repository_exception(self, fake_lib):
-        fake_lib.LibError = LibError
-        fake_lib.Repository.side_effect = LibError
-        try:
-            Create._init_repository('', '', '')
-            self.assertTrue(False, msg='Create exception expected')
-        except PulpCodedException, pe:
-            self.assertEqual(pe.error_code, errors.OST0001)
 
     def test_init(self):
         step = Create()
         self.assertEqual(step.step_id, constants.IMPORT_STEP_CREATE_REPOSITORY)
         self.assertTrue(step.description is not None)
 
-    @patch('pulp_ostree.plugins.importers.steps.mkdir')
+    @patch(MODULE + '.lib')
+    @patch(MODULE + '.Remote')
+    def test_init_repository(self, fake_remote, fake_lib):
+        url = 'url-123'
+        remote_id = 'remote-123'
+        repo_id = 'repo-123'
+        path = 'root/path-123'
+
+        fake_lib.LibError = LibError
+        fake_lib.Repository.return_value.open.side_effect = LibError
+
+        # test
+        step = Create()
+        step.parent = Mock(feed_url=url, remote_id=remote_id, repo_id=repo_id)
+        step._init_repository(path)
+
+        # validation
+        fake_remote.assert_called_once_with(step, fake_lib.Repository.return_value)
+        fake_lib.Repository.assert_called_once_with(path)
+        fake_lib.Repository.return_value.open.assert_called_once_with()
+        fake_lib.Repository.return_value.create.assert_called_once_with()
+        fake_remote.return_value.add.assert_called_once_with()
+
+    @patch(MODULE + '.lib')
+    @patch(MODULE + '.Remote')
+    def test_init_repository_exists(self, fake_remote, fake_lib):
+        url = 'url-123'
+        remote_id = 'remote-123'
+        repo_id = 'repo-xyz'
+        path = 'root/path-123'
+
+        # test
+        step = Create()
+        step.parent = Mock(feed_url=url, remote_id=remote_id, repo_id=repo_id)
+        step._init_repository(path)
+
+        # validation
+        fake_remote.assert_called_once_with(step, fake_lib.Repository.return_value)
+        fake_lib.Repository.assert_called_once_with(path)
+        fake_lib.Repository.return_value.open.assert_called_once_with()
+        fake_remote.return_value.add.assert_called_once_with()
+
+    @patch(MODULE + '.lib')
+    def test_init_repository_exception(self, fake_lib):
+        fake_lib.LibError = LibError
+        fake_lib.Repository.side_effect = LibError
+        try:
+            step = Create()
+            step.parent = Mock(feed_url='', remote_id='')
+            step._init_repository('')
+            self.assertTrue(False, msg='Create exception expected')
+        except PulpCodedException, pe:
+            self.assertEqual(pe.error_code, errors.OST0001)
+
+    @patch(MODULE + '.mkdir')
     def test_process_main(self, fake_mkdir):
         url = 'url-123'
         remote_id = 'remote-123'
@@ -119,7 +137,7 @@ class TestCreate(TestCase):
                 ((path,), {}),
                 ((os.path.join(os.path.dirname(path), constants.LINKS_DIR),), {})
             ])
-        step._init_repository.assert_called_with(path, remote_id, url)
+        step._init_repository.assert_called_with(path)
 
 
 class TestPull(TestCase):
@@ -130,13 +148,13 @@ class TestPull(TestCase):
         self.assertTrue(step.description is not None)
 
     def test_process_main(self):
-        remote_id = 'remote-123'
+        repo_id = 'repo-xyz'
         path = 'root/path-123'
         branches = ['branch-1', 'branch-2']
 
         # test
         step = Pull()
-        step.parent = Mock(storage_path=path, remote_id=remote_id, branches=branches)
+        step.parent = Mock(storage_path=path, repo_id=repo_id, branches=branches)
         step._pull = Mock()
         step.process_main()
 
@@ -144,11 +162,11 @@ class TestPull(TestCase):
         self.assertEqual(
             step._pull.call_args_list,
             [
-                ((path, remote_id, branches[0]), {}),
-                ((path, remote_id, branches[1]), {}),
+                ((path, repo_id, branches[0]), {}),
+                ((path, repo_id, branches[1]), {}),
             ])
 
-    @patch('pulp_ostree.plugins.importers.steps.lib')
+    @patch(MODULE + '.lib')
     def test_pull(self, fake_lib):
         remote_id = 'remote-123'
         path = 'root/path-123'
@@ -173,7 +191,7 @@ class TestPull(TestCase):
         step.report_progress.assert_called_with(force=True)
         self.assertEqual(step.progress_details, 'branch: branch-1 fetching 1/2 50%')
 
-    @patch('pulp_ostree.plugins.importers.steps.lib')
+    @patch(MODULE + '.lib')
     def test_pull_raising_exception(self, fake_lib):
         fake_lib.LibError = LibError
         fake_lib.Repository.return_value.pull.side_effect = LibError
@@ -192,10 +210,10 @@ class TestAdd(TestCase):
         self.assertEqual(step.step_id, constants.IMPORT_STEP_ADD_UNITS)
         self.assertTrue(step.description is not None)
 
-    @patch('pulp_ostree.plugins.importers.steps.lib')
-    @patch('pulp_ostree.plugins.importers.steps.model')
-    @patch('pulp_ostree.plugins.importers.steps.Add.link')
-    @patch('pulp_ostree.plugins.importers.steps.Unit')
+    @patch(MODULE + '.lib')
+    @patch(MODULE + '.model')
+    @patch(MODULE + '.Add.link')
+    @patch(MODULE + '.Unit')
     def test_process_main(self, fake_unit, fake_link, fake_model, fake_lib):
         remote_id = 'remote-1'
         commits = [
@@ -355,3 +373,265 @@ class TestAdd(TestCase):
         # validation
         self.assertFalse(fake_islink.called)
         self.assertFalse(fake_readlink.called)
+
+
+class TestClean(TestCase):
+
+    def test_init(self):
+        step = Clean()
+        self.assertEqual(step.step_id, constants.IMPORT_STEP_CLEAN)
+        self.assertTrue(step.description is not None)
+
+    @patch(MODULE + '.lib')
+    def test_process_main(self, fake_lib):
+        path = 'root/path-123'
+        repo_id = 'repo-123'
+
+        # test
+        step = Clean()
+        step.parent = Mock(storage_path=path, repo_id=repo_id)
+        step.process_main()
+
+        # validation
+        fake_lib.Repository.assert_called_once_with(path)
+        fake_lib.Remote.assert_called_once_with(repo_id, fake_lib.Repository.return_value)
+        fake_lib.Remote.return_value.delete.assert_called_once_with()
+
+    @patch(MODULE + '.lib')
+    def test_process_main_exception(self, fake_lib):
+        path = 'root/path-123'
+        importer_id = 'importer-xyz'
+
+        fake_lib.LibError = LibError
+        fake_lib.Remote.return_value.delete.side_effect = LibError
+
+        # test
+        try:
+            step = Clean()
+            step.parent = Mock(storage_path=path, importer_id=importer_id)
+            step.process_main()
+            self.assertTrue(False, msg='Delete remote exception expected')
+        except PulpCodedException, pe:
+            self.assertEqual(pe.error_code, errors.OST0003)
+
+
+class TestRemote(TestCase):
+
+    def test_init(self):
+        step = Mock()
+        repository = Mock()
+        remote = Remote(step, repository)
+        self.assertEqual(remote.step, step)
+        self.assertEqual(remote.repository, repository)
+
+    def test_url(self):
+        step = Mock()
+        step.parent = Mock(feed_url='http://')
+        remote = Remote(step, None)
+        self.assertEqual(remote.url, step.parent.feed_url)
+
+    def test_remote_id(self):
+        step = Mock()
+        step.parent = Mock(repo_id='123')
+        remote = Remote(step, None)
+        self.assertEqual(remote.remote_id, step.parent.repo_id)
+
+    def test_working_dir(self):
+        step = Mock()
+        remote = Remote(step, None)
+        self.assertEqual(remote.working_dir, step.get_working_dir.return_value)
+
+    def test_config(self):
+        step = Mock()
+        remote = Remote(step, None)
+        self.assertEqual(remote.config, step.get_config.return_value)
+
+    @patch('os.chmod')
+    @patch('__builtin__.open')
+    def test_ssl_key_path(self, fake_open, fake_chmod):
+        key = 'test-key'
+        config = {
+            importer_constants.KEY_SSL_CLIENT_KEY: key
+        }
+        working_dir = '/tmp/test'
+        step = Mock()
+        step.get_config.return_value = config
+        step.get_working_dir.return_value = working_dir
+        fp = Mock(__enter__=Mock(), __exit__=Mock())
+        fp.__enter__.return_value = fp
+        fake_open.return_value = fp
+
+        # test
+        remote = Remote(step, None)
+        path = remote.ssl_key_path
+
+        # validation
+        expected_path = os.path.join(working_dir, 'key.pem')
+        fake_open.assert_called_once_with(expected_path, 'w+')
+        fp.write.assert_called_once_with(key)
+        fp.__enter__.assert_called_once_with()
+        fp.__exit__.assert_called_once_with(None, None, None)
+        fake_chmod.assert_called_once_with(expected_path, 0600)
+        self.assertEqual(path, expected_path)
+
+    @patch('__builtin__.open')
+    def test_ssl_cert_path(self, fake_open):
+        cert = 'test-key'
+        config = {
+            importer_constants.KEY_SSL_CLIENT_CERT: cert
+        }
+        working_dir = '/tmp/test'
+        step = Mock()
+        step.get_config.return_value = config
+        step.get_working_dir.return_value = working_dir
+        fp = Mock(__enter__=Mock(), __exit__=Mock())
+        fp.__enter__.return_value = fp
+        fake_open.return_value = fp
+
+        # test
+        remote = Remote(step, None)
+        path = remote.ssl_cert_path
+
+        # validation
+        expected_path = os.path.join(working_dir, 'cert.pem')
+        fake_open.assert_called_once_with(expected_path, 'w+')
+        fp.write.assert_called_once_with(cert)
+        fp.__enter__.assert_called_once_with()
+        fp.__exit__.assert_called_once_with(None, None, None)
+        self.assertEqual(path, expected_path)
+
+    @patch('__builtin__.open')
+    def test_ssl_ca_path(self, fake_open):
+        cert = 'test-key'
+        config = {
+            importer_constants.KEY_SSL_CA_CERT: cert
+        }
+        working_dir = '/tmp/test'
+        step = Mock()
+        step.get_config.return_value = config
+        step.get_working_dir.return_value = working_dir
+        fp = Mock(__enter__=Mock(), __exit__=Mock())
+        fp.__enter__.return_value = fp
+        fake_open.return_value = fp
+
+        # test
+        remote = Remote(step, None)
+        path = remote.ssl_ca_path
+
+        # validation
+        expected_path = os.path.join(working_dir, 'ca.pem')
+        fake_open.assert_called_once_with(expected_path, 'w+')
+        fp.write.assert_called_once_with(cert)
+        fp.__enter__.assert_called_once_with()
+        fp.__exit__.assert_called_once_with(None, None, None)
+        self.assertEqual(path, expected_path)
+
+    def test_ssl_validation(self):
+        config = {
+            importer_constants.KEY_SSL_VALIDATION: True
+        }
+        step = Mock()
+        step.get_config.return_value = config
+
+        # test
+        remote = Remote(step, None)
+        validation = remote.ssl_validation
+
+        # validation
+        self.assertTrue(validation)
+        self.assertTrue(isinstance(validation, bool))
+
+    def test_ssl_validation_not_specified(self):
+        config = {}
+        step = Mock()
+        step.get_config.return_value = config
+
+        # test
+        remote = Remote(step, None)
+        validation = remote.ssl_validation
+
+        # validation
+        self.assertFalse(validation)
+        self.assertTrue(isinstance(validation, bool))
+
+    @patch(MODULE + '.GPG')
+    def test_gpg_key(self, fake_gpg):
+        keys = [1, 2, 3]
+        key_list = [dict(keyid=k) for k in keys]
+        working_dir = '/tmp/test'
+        config = {
+            constants.IMPORTER_CONFIG_KEY_GPG_KEYS: keys
+        }
+        step = Mock()
+        step.get_config.return_value = config
+        step.get_working_dir.return_value = working_dir
+
+        fake_gpg.return_value.list_keys.return_value = key_list
+
+        # test
+        remote = Remote(step, None)
+        path, key_ids = remote.gpg_keys
+
+        # validation
+        fake_gpg.assert_called_once_with(gnupghome=working_dir)
+        self.assertEqual(
+            fake_gpg.return_value.import_keys.call_args_list,
+            [((k,), {}) for k in keys])
+        self.assertEqual(path, os.path.join(working_dir, 'pubring.gpg'))
+        self.assertEqual(key_ids, [k['keyid'] for k in key_list])
+
+    def test_proxy_url(self):
+        host = 'proxy-host'
+        port = 'proxy-port'
+        user = 'proxy-user'
+        password = 'proxy-password'
+        config = {
+            importer_constants.KEY_PROXY_HOST: host,
+            importer_constants.KEY_PROXY_PORT: port,
+            importer_constants.KEY_PROXY_USER: user,
+            importer_constants.KEY_PROXY_PASS: password,
+        }
+        step = Mock()
+        step.get_config.return_value = config
+
+        proxy_url = '@'.join(
+            (':'.join((user, password)),
+             ':'.join((host, port))))
+
+        # test
+        remote = Remote(step, None)
+
+        # validation
+        self.assertEqual(remote.proxy_url, proxy_url)
+
+    @patch(MODULE + '.lib')
+    @patch(MODULE + '.Remote.url', PropertyMock())
+    @patch(MODULE + '.Remote.remote_id', PropertyMock())
+    @patch(MODULE + '.Remote.ssl_key_path', PropertyMock())
+    @patch(MODULE + '.Remote.ssl_cert_path', PropertyMock())
+    @patch(MODULE + '.Remote.ssl_ca_path', PropertyMock())
+    @patch(MODULE + '.Remote.ssl_validation', PropertyMock())
+    @patch(MODULE + '.Remote.proxy_url', PropertyMock())
+    @patch(MODULE + '.Remote.gpg_keys', new_callable=PropertyMock)
+    def test_add(self, fake_gpg, fake_lib):
+        step = Mock()
+        repository = Mock()
+        path = Mock()
+        key_ids = [1, 2, 3]
+        fake_gpg.return_value = (path, key_ids)
+
+        # test
+        remote = Remote(step, repository)
+        remote.add()
+
+        # validation
+        fake_lib.Remote.assert_called_once_with(remote.remote_id, repository)
+        fake_lib.Remote.return_value.update.assert_called_once_with()
+        fake_lib.Remote.return_value.import_key.assert_called_once_with(path, key_ids)
+        self.assertEqual(fake_lib.Remote.return_value.url, remote.url)
+        self.assertEqual(fake_lib.Remote.return_value.ssl_key_path, remote.ssl_key_path)
+        self.assertEqual(fake_lib.Remote.return_value.ssl_cert_path, remote.ssl_cert_path)
+        self.assertEqual(fake_lib.Remote.return_value.ssl_ca_path, remote.ssl_ca_path)
+        self.assertEqual(fake_lib.Remote.return_value.ssl_validation, remote.ssl_validation)
+        self.assertEqual(fake_lib.Remote.return_value.proxy_url, remote.proxy_url)
+        self.assertTrue(fake_lib.Remote.return_value.gpg_validation, remote.ssl_validation)

--- a/pulp-ostree.spec
+++ b/pulp-ostree.spec
@@ -102,6 +102,7 @@ Requires: python-pulp-ostree-common = %{version}
 Requires: pulp-server >= 2.7
 Requires: python-setuptools
 Requires: ostree >= 2015.3.49
+Requires: python-gnupg
 Requires: pygobject3
 
 %description plugins


### PR DESCRIPTION
https://pulp.plan.io/issues/912

This PR is issued against a feature branch because there are outstanding issues documented in the story.  For example: the version of libostree needed here has not yet been packaged and released.

Add support for SSL & GPG options.  This additional functionality required much richer support for configuring the ostree remote.  It also introduced conditions whereby multiple pulp repositories with the same feed (remote) could interfere with each others configuration of that *remote*.  So, this PR also changes things so that each importer creates a temporary ostree remote using the *repo_id* instead of the *remote_id* which really uniquely identifies the upstream.  The temporary ostree remote is created, configured and deleted for each sync.  This ensures that multiple pulp repositories pulling from the same (upstream) ostree repository are doing so using there own ostree remotes and not sharing one.

Both the *lib* and and the *steps* are refactored to have 1st class objects to support an ostree *Remote*.

The addition of the *Summary* and generating the summary are added as a side item and not related to the story..  Pulp should generate the summary as part of publishing.