### PR TITLE
Fix unit tests that fail against Pulp master

### DIFF
--- a/plugins/pulp_ostree/plugins/distributors/steps.py
+++ b/plugins/pulp_ostree/plugins/distributors/steps.py
@@ -22,20 +22,20 @@ class WebPublisher(PluginStep):
     of a repository via a web server
     """
 
-    def __init__(self, repo, conduit, config):
+    def __init__(self, repo, conduit, config, working_dir=None, **kwargs):
         """
-        :param repo: Pulp managed Yum repository
+        :param repo: The repo being worked on
         :type  repo: pulp.plugins.model.Repository
-        :param conduit: Conduit providing access to relative Pulp functionality
+        :param conduit: The conduit for the repo
         :type  conduit: pulp.plugins.conduits.repo_publish.RepoPublishConduit
         :param config: Pulp configuration for the distributor
         :type  config: pulp.plugins.config.PluginCallConfiguration
+        :param working_dir: The temp directory this step should use for processing
+        :type  working_dir: str
         """
-        super(WebPublisher, self).__init__(
-            constants.PUBLISH_STEP_WEB_PUBLISHER,
-            repo,
-            conduit,
-            config)
+        super(WebPublisher, self).__init__(constants.PUBLISH_STEP_WEB_PUBLISHER,
+                                           repo, conduit, config, working_dir,
+                                           plugin_type=constants.WEB_DISTRIBUTOR_TYPE_ID, **kwargs)
 
         publish_dir = configuration.get_web_publish_dir(repo, config)
         self.web_working_dir = os.path.join(self.get_working_dir(), repo.id)

--- a/plugins/test/unit/plugins/distributors/test_steps.py
+++ b/plugins/test/unit/plugins/distributors/test_steps.py
@@ -26,7 +26,7 @@ class TestWebPublisher(unittest.TestCase):
         mock_configuration.get_master_publish_dir.return_value = master_pub_dir
 
         # test
-        publisher = steps.WebPublisher(repo, conduit, config)
+        publisher = steps.WebPublisher(repo, conduit, config, working_dir='/tmp/working')
 
         # validation
         mock_atomic.assert_called_once_with(
@@ -70,7 +70,7 @@ class TestMainStep(unittest.TestCase):
         lib.Repository.return_value = ostree_repo
 
         # test
-        main = steps.MainStep()
+        main = steps.MainStep(working_dir=working_dir)
         main._get_units = Mock(return_value=units)
         main.parent = parent
         main.process_main()


### PR DESCRIPTION
I noticed that https://github.com/pulp/pulp_ostree/pull/31 had unit tests that fail for pulp:master. This PR updates the WebPublisher `__init__` to match the super class signature and fixes the tests using the now-available working_dir. 