### PR TITLE
Auto-publish now defaults to true.

### DIFF
--- a/extensions_admin/pulp_ostree/extensions/admin/cudl.py
+++ b/extensions_admin/pulp_ostree/extensions/admin/cudl.py
@@ -66,8 +66,9 @@ class CreateOSTreeRepositoryCommand(CreateAndConfigureRepositoryCommand, Importe
                     that would be passed to the RepoDistributorAPI.create call).
         :rtype:     list of dict
         """
+
         relative_path = user_input.get(OPT_RELATIVE_PATH.keyword)
-        auto_publish = user_input.get(OPT_AUTO_PUBLISH.keyword, True)
+        auto_publish = user_input.get(OPT_AUTO_PUBLISH.keyword)
 
         # relative path derived using the path component of the feed url when not specified
         if not relative_path:
@@ -75,6 +76,9 @@ class CreateOSTreeRepositoryCommand(CreateAndConfigureRepositoryCommand, Importe
             if feed_url:
                 url = urlparse(feed_url)
                 relative_path = url.path
+
+        if auto_publish is None:
+            auto_publish = True
 
         config = {
             constants.DISTRIBUTOR_CONFIG_KEY_RELATIVE_PATH: relative_path

--- a/extensions_admin/test/unit/admin/test_cudl.py
+++ b/extensions_admin/test/unit/admin/test_cudl.py
@@ -59,6 +59,12 @@ class TestCreateOSTreerRepositoryCommand(unittest.TestCase):
         result = command._describe_distributors(user_input)
         self.assertEquals(result[0]["auto_publish"], False)
 
+    def test_describe_distributors_default_auto_publish(self):
+        command = cudl.CreateOSTreeRepositoryCommand(Mock())
+        user_input = {}
+        result = command._describe_distributors(user_input)
+        self.assertEquals(result[0]["auto_publish"], True)
+
     def test_describe_importers(self):
         command = cudl.CreateOSTreeRepositoryCommand(Mock())
         user_input = {'branch': ['apple']}


### PR DESCRIPTION
closes #1074
https://pulp.plan.io/issues/1074

Issue was only in CLI.

Server side did not have any issues:
- if auto_publish was not specified at all , then in config it was False
- if auto_publish was specified and value was True, then in config it was True

This way work other content types, I specifically checked the rpm repo creation behaviour via API.