### PR TITLE
Fetch and store remote summary information in repo scratchpad.

### DIFF
--- a/common/pulp_ostree/common/constants.py
+++ b/common/pulp_ostree/common/constants.py
@@ -6,6 +6,11 @@ OSTREE_TYPE_ID = 'ostree'
 REPO_NOTE_OSTREE = 'OSTREE'
 
 
+# Scratchpad
+REMOTE = 'remote'
+SUMMARY = 'summary'
+
+
 # Plugins
 WEB_IMPORTER_TYPE_ID = 'ostree_web_importer'
 WEB_DISTRIBUTOR_TYPE_ID = 'ostree_web_distributor'


### PR DESCRIPTION
https://pulp.plan.io/issues/897

Incidental improvements:
- Repository subclass object.
- Add step subclass SaveUnitsStep so counts get updated.
- Ref.path renamed to Ref.name for more correct semantics.

The platform needs to be updated include the scratchpad in the serialized repository.