### PR TITLE
Support pulling all branches

### DIFF
--- a/common/pulp_ostree/common/constants.py
+++ b/common/pulp_ostree/common/constants.py
@@ -30,6 +30,7 @@ DISTRIBUTOR_CONFIG_KEY_RELATIVE_PATH = 'relative_path'
 # Steps
 IMPORT_STEP_MAIN = 'import_main'
 IMPORT_STEP_CREATE_REPOSITORY = 'import_create_repository'
+IMPORT_STEP_SUMMARY = 'import_summary'
 IMPORT_STEP_PULL = 'import_pull'
 IMPORT_STEP_ADD_UNITS = 'import_add_unit'
 IMPORT_STEP_CLEAN = 'import_clean'

--- a/common/pulp_ostree/common/errors.py
+++ b/common/pulp_ostree/common/errors.py
@@ -8,8 +8,8 @@ OST0001 = Error('OST0001',
                 ['path', 'reason'])
 
 OST0002 = Error('OST0002',
-                _('Pulling remote branch: %(branch)s failed.  Reason: %(reason)s'),
-                ['branch', 'reason'])
+                _('Pulling remote refs failed.  Reason: %(reason)s'),
+                ['reason'])
 
 OST0003 = Error('OST0003',
                 _('Delete remote: %(id)s failed.  Reason: %(reason)s'),

--- a/plugins/pulp_ostree/plugins/importers/steps.py
+++ b/plugins/pulp_ostree/plugins/importers/steps.py
@@ -129,7 +129,7 @@ class Pull(PluginStep):
 
     def process_main(self, item=None):
         """
-        Pull  each of the specified branches using the temporary remote
+        Pull each of the specified branches using the temporary remote
         configured using the repo_id as the remote_id.
 
         :raises PulpCodedException:
@@ -138,7 +138,7 @@ class Pull(PluginStep):
 
     def _pull(self, path, remote_id, refs):
         """
-        Pull  the specified branch.
+        Pull the specified branch.
 
         :param path: The absolute path to the local repository.
         :type path: str

--- a/plugins/pulp_ostree/plugins/importers/steps.py
+++ b/plugins/pulp_ostree/plugins/importers/steps.py
@@ -8,7 +8,7 @@ from gnupg import GPG
 from mongoengine import NotUniqueError
 
 from pulp.common.plugins import importer_constants
-from pulp.plugins.util.publish_step import PluginStep
+from pulp.plugins.util.publish_step import PluginStep, SaveUnitsStep
 from pulp.server.content.storage import SharedStorage
 from pulp.server.controllers.repository import associate_single_unit
 from pulp.server.exceptions import PulpCodedException
@@ -21,6 +21,9 @@ from pulp_ostree.plugins import lib
 log = getLogger(__name__)
 
 
+ALL = None  # all branches (refs)
+
+
 class Main(PluginStep):
     """
     The main synchronization step.
@@ -31,14 +34,24 @@ class Main(PluginStep):
             step_type=constants.IMPORT_STEP_MAIN,
             plugin_type=constants.WEB_IMPORTER_TYPE_ID,
             **kwargs)
-        self.feed_url = self.config.get(importer_constants.KEY_FEED)
-        self.branches = self.config.get(constants.IMPORTER_CONFIG_KEY_BRANCHES, [])
         self.remote_id = model.generate_remote_id(self.feed_url)
-        self.repo_id = self.get_repo().repo_id
         self.add_child(Create())
+        self.add_child(Summary())
         self.add_child(Pull())
         self.add_child(Add())
         self.add_child(Clean())
+
+    @property
+    def feed_url(self):
+        return self.config.get(importer_constants.KEY_FEED)
+
+    @property
+    def branches(self):
+        return self.config.get(constants.IMPORTER_CONFIG_KEY_BRANCHES, ALL)
+
+    @property
+    def repo_id(self):
+        return self.get_repo().repo_id
 
     @property
     def storage_dir(self):
@@ -80,73 +93,16 @@ class Create(PluginStep):
             raise pe
 
 
-class Pull(PluginStep):
+class Summary(PluginStep):
     """
-    Pull each of the specified branches.
-    """
-
-    def __init__(self):
-        super(Pull, self).__init__(step_type=constants.IMPORT_STEP_PULL)
-        self.description = _('Pull Remote Branches')
-
-    def process_main(self, item=None):
-        """
-        Pull each of the specified branches using the temporary remote
-        configured using the repo_id as the remote_id.
-
-        :raises PulpCodedException:
-        """
-        for branch_id in self.parent.branches:
-            self._pull(self.parent.storage_dir, self.parent.repo_id, branch_id)
-
-    def _pull(self, path, remote_id, branch_id):
-        """
-        Pull the specified branch.
-
-        :param path: The absolute path to the local repository.
-        :type path: str
-        :param remote_id: The remote ID.
-        :type remote_id: str
-        :param branch_id: The branch to pull.
-        :type branch_id: str
-        :raises PulpCodedException:
-        """
-        def report_progress(report):
-            data = dict(
-                b=branch_id,
-                f=report.fetched,
-                r=report.requested,
-                p=report.percent
-            )
-            self.progress_details = 'branch: %(b)s fetching %(f)d/%(r)d %(p)d%%' % data
-            self.report_progress(force=True)
-
-        try:
-            repository = lib.Repository(path)
-            repository.pull(remote_id, [branch_id], report_progress)
-        except lib.LibError, le:
-            pe = PulpCodedException(errors.OST0002, branch=branch_id, reason=str(le))
-            raise pe
-
-
-class Add(PluginStep):
-    """
-    Add content units.
+    Update the summary information stored in the repository scratchpad.
     """
 
     def __init__(self):
-        super(Add, self).__init__(step_type=constants.IMPORT_STEP_ADD_UNITS)
-        self.description = _('Add Content Units')
+        super(Summary, self).__init__(step_type=constants.IMPORT_STEP_SUMMARY)
+        self.description = _('Update Summary')
 
     def process_main(self, item=None):
-        """
-        Get the remote summary and add/update the repository
-        scratchpad.  Then, add the content unit and associate to the repository.
-        """
-        self.add_summary()
-        self.add_units()
-
-    def add_summary(self):
         """
         Add/update the remote summary information in the
         repository scratchpad.
@@ -161,16 +117,74 @@ class Add(PluginStep):
         })
         repository.save()
 
-    def add_units(self):
+
+class Pull(PluginStep):
+    """
+    Pull each of the specified branches.
+    """
+
+    def __init__(self):
+        super(Pull, self).__init__(step_type=constants.IMPORT_STEP_PULL)
+        self.description = _('Pull Remote Branches')
+
+    def process_main(self, item=None):
+        """
+        Pull  each of the specified branches using the temporary remote
+        configured using the repo_id as the remote_id.
+
+        :raises PulpCodedException:
+        """
+        self._pull(self.parent.storage_dir, self.parent.repo_id, self.parent.branches)
+
+    def _pull(self, path, remote_id, refs):
+        """
+        Pull  the specified branch.
+
+        :param path: The absolute path to the local repository.
+        :type path: str
+        :param remote_id: The remote ID.
+        :type remote_id: str
+        :param refs: The refs to pull.
+        :type refs: list
+        :raises PulpCodedException:
+        """
+        def report_progress(report):
+            data = dict(
+                f=report.fetched,
+                r=report.requested,
+                p=report.percent
+            )
+            self.progress_details = 'fetching %(f)d/%(r)d %(p)d%%' % data
+            self.report_progress(force=True)
+
+        try:
+            repository = lib.Repository(path)
+            repository.pull(remote_id, refs, report_progress)
+        except lib.LibError, le:
+            pe = PulpCodedException(errors.OST0002, reason=str(le))
+            raise pe
+
+
+class Add(SaveUnitsStep):
+    """
+    Add content units.
+    """
+
+    def __init__(self):
+        super(Add, self).__init__(step_type=constants.IMPORT_STEP_ADD_UNITS)
+        self.description = _('Add Content Units')
+
+    def process_main(self, item=None):
         """
         Find all branch (heads) in the local repository and
         create content units for them.
         """
         lib_repository = lib.Repository(self.parent.storage_dir)
         for ref in lib_repository.list_refs():
-            if ref.path not in self.parent.branches:
-                # not listed
-                continue
+            if self.parent.branches is not ALL:
+                if ref.path not in self.parent.branches:
+                    # not listed
+                    continue
             unit = model.Branch(
                 remote_id=self.parent.remote_id,
                 branch=ref.path,


### PR DESCRIPTION
https://pulp.plan.io/issues/1178

The main change here is to change the behavior of having the 'branches' import configuration property either unspecified or None (NULL).  This makes sense because the only use case for pull with no branches would be to refresh the summary information stored in the repository scratchpad.  This can still be done by specifying branches = [] in the configuration override in the sync API call.  I doubt there is a legit use case for actually storing the branches = [].

Other changes:
- pull all references using a single PULL call to the lib.  This is more efficient.
- moving attributes in the Main step to properties.  No point in storing the information twice.
- Making *Summary* it's own step.  This is usually fast but could potentially be long running.  Also, this paves the way for doing a *refresh the summary only* operation in the future.
