### PR TITLE
Removes a spec file entry for ostree.json which was removed

### DIFF
--- a/pulp-ostree.spec
+++ b/pulp-ostree.spec
@@ -114,7 +114,6 @@ to provide OSTree specific support.
 %{python_sitelib}/pulp_ostree/plugins/
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/pulp_ostree.conf
 %config(noreplace) %{_sysconfdir}/pulp/server/plugins.conf.d/ostree_*.json
-%{_usr}/lib/pulp/plugins/types/ostree.json
 %{python_sitelib}/pulp_ostree_plugins*.egg-info
 %defattr(-,apache,apache,-)
 %{_var}/lib/pulp/published/ostree/


### PR DESCRIPTION
The file ostree.json was removed as part of the mongoengine
conversion. This line should have been removed with it.

ostree.json was removed with https://github.com/pulp/pulp_ostree/commit/76ee063e97a692c27533e75687808437fdae5fb6#diff-0cb394973dd7524ed1f7ffb096ac8a93