### PR TITLE
Updates plugin to match platform changes on ContentUnit

### DIFF
--- a/plugins/pulp_ostree/plugins/db/model.py
+++ b/plugins/pulp_ostree/plugins/db/model.py
@@ -81,9 +81,8 @@ class Branch(SharedContentUnit):
 
     # backward compatibility
     _ns = StringField(required=True, default=meta['collection'])
-    unit_type_id = StringField(
+    _content_type_id = StringField(
         required=True,
-        db_field='_content_type_id',
         default=constants.OSTREE_TYPE_ID)
 
     @classmethod

--- a/plugins/pulp_ostree/plugins/distributors/steps.py
+++ b/plugins/pulp_ostree/plugins/distributors/steps.py
@@ -88,7 +88,7 @@ class MainStep(PluginStep):
         :rtype: iterable
         """
         units = {}
-        query = Q(unit_type_id=constants.OSTREE_TYPE_ID)
+        query = Q(_content_type_id=constants.OSTREE_TYPE_ID)
         associations = find_repo_content_units(
             self.get_repo(),
             repo_content_unit_q=query)

--- a/plugins/test/unit/plugins/distributors/test_steps.py
+++ b/plugins/test/unit/plugins/distributors/test_steps.py
@@ -104,7 +104,7 @@ class TestMainStep(unittest.TestCase):
         unit_list = main._get_units()
 
         # validation
-        q.assert_called_once_with(unit_type_id=constants.OSTREE_TYPE_ID)
+        q.assert_called_once_with(_content_type_id=constants.OSTREE_TYPE_ID)
         find.assert_called_once_with(
             parent.get_repo.return_value, repo_content_unit_q=q.return_value)
         self.assertEqual(


### PR DESCRIPTION
closes#1351

- renames unit_type_id to _content_type_id
- updates tests so they pass too