### PR TITLE
Removed types/ directory references.

### DIFF
--- a/pulp-ostree.spec
+++ b/pulp-ostree.spec
@@ -43,7 +43,6 @@ popd
 rm -rf %{buildroot}
 
 mkdir -p %{buildroot}/%{_sysconfdir}/pulp/
-mkdir -p %{buildroot}/%{_usr}/lib/pulp/plugins/types
 mkdir -p %{buildroot}/%{_var}/lib/pulp/published/ostree/
 mkdir -p %{buildroot}/%{_bindir}
 
@@ -60,7 +59,6 @@ pushd plugins
 popd
 
 cp -R plugins/etc %{buildroot}
-cp -R plugins/types/* %{buildroot}/%{_usr}/lib/pulp/plugins/types/
 
 # Remove tests
 rm -rf %{buildroot}/%{python_sitelib}/test


### PR DESCRIPTION
Fixes:
```
//usr/lib/pulp/plugins/types/
cp: cannot stat 'plugins/types/*': No such file or directory
RPM build errors:
error: Bad exit status from /var/tmp/rpm-tmp.Tz9qLH (%install)
```
Errors seen in koji.