### PR TITLE
Store WSGI scripts in /usr/share/pulp/wsgi instead of /srv.

### DIFF
--- a/plugins/etc/httpd/conf.d/pulp_ostree.conf
+++ b/plugins/etc/httpd/conf.d/pulp_ostree.conf
@@ -7,7 +7,7 @@
 Alias /pulp/ostree /var/www/pub/ostree/
 
 <Directory /var/www/pub/ostree>
-    WSGIAccessScript /srv/pulp/repo_auth.wsgi
+    WSGIAccessScript /usr/share/pulp/wsgi/repo_auth.wsgi
     SSLRequireSSL
     SSLVerifyClient optional_no_ca
     SSLVerifyDepth 2


### PR DESCRIPTION
https://pulp.plan.io/issues/1496

re #1496

It doesn't seem like the spec file or the pulp-dev.py scripts are installing ostree which I found puzzling.