### PR TITLE
Configures Sphinx docs config to not look for static media

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
Prior to this fix when building the docs you would see a warning
like:

```
html_static_path entry u'/path/to/pulp_ostree/docs/_static' does not exist
```

https://pulp.plan.io/issues/950
re #950