### PR TITLE
Add gnupg as dependency

### DIFF
--- a/pulp-ostree.spec
+++ b/pulp-ostree.spec
@@ -98,6 +98,7 @@ Requires: pulp-server >= %{platform_version}
 Requires: python-setuptools
 Requires: ostree >= 2015.8
 Requires: python-gnupg
+Requires: gnupg
 Requires: pygobject3
 
 %description plugins


### PR DESCRIPTION
closes #1934
https://pulp.plan.io/issues/1934

We will need to carry gnupg as dependency until bz#1342154 and 1342161
are not fixed.