### PR TITLE
Add provides for python2-* packages

### DIFF
--- a/pulp-ostree.spec
+++ b/pulp-ostree.spec
@@ -69,6 +69,7 @@ rm -rf %{buildroot}
 %package -n python-pulp-ostree-common
 Summary: Pulp OSTree support common library
 Group: Development/Languages
+Provides: python2-pulp-ostree-common
 Requires: python-pulp-common >= %{platform_version}
 Requires: python-setuptools
 


### PR DESCRIPTION
Add provides for python2-* packages.  Fedora downstream packages are
named python2-* and provide python-*.  Upstream needs to mirror this for
dependency resolution to work properly

re #2687