### PR TITLE
Bump platform version in specfile

### DIFF
--- a/pulp-ostree.spec
+++ b/pulp-ostree.spec
@@ -2,7 +2,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 # Required platform version
-%global platform_version 2.8
+%global platform_version 2.10
 
 
 Name: pulp-ostree


### PR DESCRIPTION
This is needed because `override_config_options` introduced
in Pulp 2.10 are used in OSTree plugin.