### PR TITLE
Publish correct branch head and depth.

### DIFF
--- a/plugins/pulp_ostree/plugins/db/model.py
+++ b/plugins/pulp_ostree/plugins/db/model.py
@@ -1,7 +1,6 @@
-from datetime import datetime
 from hashlib import sha256
 
-from mongoengine import DateTimeField, StringField, DictField
+from mongoengine import StringField, DictField
 from pulp.server.db.model import SharedContentUnit
 
 from pulp_ostree.common import constants
@@ -61,10 +60,8 @@ class Branch(SharedContentUnit):
     :type remote_id: str
     :cvar branch: The branch path.
     :type branch: str
-    :cvar commit: A commit.
+    :cvar commit: A commit ID.
     :type commit: str
-    :cvar created: The created (UTC) timestamp.
-    :type created: datetime
     :cvar metadata: The commit metadata.
     :type metadata: dict
     """
@@ -74,7 +71,6 @@ class Branch(SharedContentUnit):
     branch = StringField(required=True)
     commit = StringField(required=True)
     # other
-    created = DateTimeField(db_field='_created', required=True)
     metadata = MetadataField()
 
     unit_key_fields = (
@@ -94,20 +90,6 @@ class Branch(SharedContentUnit):
     _content_type_id = StringField(
         required=True,
         default=constants.OSTREE_TYPE_ID)
-
-    @classmethod
-    def pre_save_signal(cls, sender, document, **kwargs):
-        """
-        The signal that is triggered before a unit is saved.
-        Set the storage_path on the document and add the symbolic link.
-
-        :param sender: sender class
-        :type sender: object
-        :param document: Document that sent the signal
-        :type document: SharedContentUnit
-        """
-        super(Branch, cls).pre_save_signal(sender, document, **kwargs)
-        document.created = datetime.utcnow()
 
     @property
     def storage_provider(self):

--- a/plugins/pulp_ostree/plugins/migrations/0001_timestamp.py
+++ b/plugins/pulp_ostree/plugins/migrations/0001_timestamp.py
@@ -1,0 +1,18 @@
+"""
+Migration to remove Branch._created which is no longer used.
+"""
+
+from pulp.server.db import connection
+
+
+def migrate(*args, **kwargs):
+    """
+    Remove Branch._created which is no longer used.
+
+    :param args: unused
+    :type  args: tuple
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    collection = connection.get_collection('units_ostree')
+    collection.update_many({}, {'$unset': {'_created': ''}})

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -21,6 +21,9 @@ setup(
         ],
         'pulp.unit_models': [
             'ostree=pulp_ostree.plugins.db.model:Branch'
-        ]
+        ],
+        'pulp.server.db.migrations': [
+            'pulp_ostree = pulp_ostree.plugins.migrations'
+        ],
     }
 )

--- a/plugins/test/unit/plugins/db/test_model.py
+++ b/plugins/test/unit/plugins/db/test_model.py
@@ -1,7 +1,6 @@
 from hashlib import sha256
 from unittest import TestCase
 
-from mock import patch, Mock
 import mongoengine
 
 from pulp_ostree.common import constants
@@ -56,20 +55,6 @@ class TestMetadataField(TestCase):
 
 
 class TestBranch(TestCase):
-
-    @patch('pulp_ostree.plugins.db.model.datetime')
-    def test_pre_save_signal(self, datetime):
-        sender = Mock()
-        kwargs = {'a': 1, 'b': 2}
-
-        # test
-        unit = Branch()
-        with patch('pulp.server.db.model.SharedContentUnit.pre_save_signal') as base:
-            unit.pre_save_signal(sender, unit, **kwargs)
-
-        # validation
-        base.assert_called_once_with(sender, unit, **kwargs)
-        self.assertEqual(unit.created, datetime.utcnow.return_value)
 
     def test_storage_provider(self):
         unit = Branch()

--- a/plugins/test/unit/plugins/importers/test_steps.py
+++ b/plugins/test/unit/plugins/importers/test_steps.py
@@ -277,9 +277,15 @@ class TestAdd(unittest.TestCase):
     def test_process_main(self, fake_associate, fake_model, fake_lib):
         def history(commit_id):
             return [
-                Commit(id='{}head'.format(commit_id), metadata={'version': 1}),
-                Commit(id='{}parent-1'.format(commit_id), metadata={'version': 2}),
-                Commit(id='{}parent-2'.format(commit_id), metadata={'version': 3}),
+                Commit(id='{}head'.format(commit_id),
+                       parent_id='unused',
+                       metadata={'version': 1}),
+                Commit(id='{}parent-1'.format(commit_id),
+                       parent_id='unused',
+                       metadata={'version': 2}),
+                Commit(id='{}parent-2'.format(commit_id),
+                       parent_id='unused',
+                       metadata={'version': 3}),
             ]
         repo_id = 'r-1234'
         remote_id = 'remote-1'

--- a/plugins/test/unit/plugins/test_lib.py
+++ b/plugins/test/unit/plugins/test_lib.py
@@ -23,7 +23,7 @@ class Import(object):
     def __init__(self):
         self.mod = Mock()
 
-    def __call__(self, ignored, fromlist):
+    def __call__(self, ignored, fromlist=()):
         for name in fromlist:
             setattr(self.mod, name, hash(name))
         return self.mod
@@ -64,7 +64,7 @@ class TestLoad(TestCase):
         lib = Lib()
 
         # validation
-        self.assertEqual(_import.call_count, len(lib.__dict__))
+        self.assertEqual(_import.call_count, 1 + len(lib.__dict__))
         for name in lib.__dict__.keys():
             _import.assert_any_call(G_OBJECT, fromlist=[name])
             self.assertEqual(getattr(lib, name), hash(name))
@@ -548,9 +548,9 @@ class TestRepository(TestCase):
 
         # validation
         self.assertEqual(history, [
-            Commit('123', {'version': 1}),
-            Commit('456', {'version': 2}),
-            Commit('789', {'version': 3}),
+            Commit(id='123', parent_id='456', metadata={'version': 1}),
+            Commit(id='456', parent_id='789', metadata={'version': 2}),
+            Commit(id='789', parent_id=None, metadata={'version': 3}),
         ])
 
     @patch('pulp_ostree.plugins.lib.Lib')
@@ -560,7 +560,6 @@ class TestRepository(TestCase):
         commit_id = '123'
         parents = [
             '456',
-            '789',
             None
         ]
         variants = [
@@ -583,8 +582,8 @@ class TestRepository(TestCase):
 
         # validation
         self.assertEqual(history, [
-            Commit('123', {'version': 1}),
-            Commit('456', {'version': 2}),
+            Commit(id='123', parent_id='456', metadata={'version': 1}),
+            Commit(id='456', parent_id=None, metadata={'version': 2}),
         ])
 
     @patch('pulp_ostree.plugins.lib.Lib')


### PR DESCRIPTION
https://pulp.plan.io/issues/3999

This does not implement the proposed solution 3999.  Instead, it uses the history available in the local ostree repository to determine the available depth and branch HEAD.
