### PR TITLE
Clearly mark pulp2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 pulp_ostree
 ===========
+
+OSTree support for the Pulp 2.y Platform


### PR DESCRIPTION
The readme didn't indicate which verison of Pulp it was for. This
clearly marks it as Pulp2.

https://pulp.plan.io/issues/4642
closes #4642