### PR TITLE
Publish content at the path specified by a distribution

### DIFF
--- a/CHANGES/143.bugfix
+++ b/CHANGES/143.bugfix
@@ -1,0 +1,1 @@
+Fixed content paths for published distributions.

--- a/pulp_ostree/app/tasks/importing.py
+++ b/pulp_ostree/app/tasks/importing.py
@@ -54,12 +54,12 @@ def import_ostree_content(
             tarball_artifact, repository_name, parent_commit, ref
         )
     else:
-        first_stage = OstreeImportAllBranchesFirstStage(tarball_artifact, repository_name)
+        first_stage = OstreeImportAllRefsFirstStage(tarball_artifact, repository_name)
     dv = OstreeImportDeclarativeVersion(first_stage, repository)
     return dv.create()
 
 
-class OstreeSingleBranchParserMixin:
+class OstreeSingleRefParserMixin:
     """A mixin class that allows stages to share the same methods for parsing OSTree data."""
 
     async def parse_ref(self, name, ref_commit_checksum, ref_parent_checksum=None):
@@ -161,7 +161,7 @@ class OstreeImportStage(Stage):
 
 
 class OstreeImportSingleRefFirstStage(
-    DeclarativeContentCreatorMixin, OstreeSingleBranchParserMixin, OstreeImportStage
+    DeclarativeContentCreatorMixin, OstreeSingleRefParserMixin, OstreeImportStage
 ):
     """A first stage of the OSTree importing pipeline that appends child commits to a repository."""
 
@@ -222,8 +222,8 @@ class OstreeImportSingleRefFirstStage(
         self.init_ref_object(self.ref, ref_relative_path, commit_dc)
 
 
-class OstreeImportAllBranchesFirstStage(
-    DeclarativeContentCreatorMixin, OstreeSingleBranchParserMixin, OstreeImportStage
+class OstreeImportAllRefsFirstStage(
+    DeclarativeContentCreatorMixin, OstreeSingleRefParserMixin, OstreeImportStage
 ):
     """A first stage of the OSTree importing pipeline that handles creation of content units."""
 

--- a/pulp_ostree/app/tasks/stages.py
+++ b/pulp_ostree/app/tasks/stages.py
@@ -62,8 +62,7 @@ class DeclarativeContentCreatorMixin:
         """Create a DeclarativeContent object describing a single OSTree object (e.g., commit)."""
         artifact = self.init_artifact(relative_file_path)
 
-        publication_filepath = os.path.join(self.repo_name, relative_file_path)
-        content.relative_path = publication_filepath
+        content.relative_path = relative_file_path
 
         # DeclarativeArtifact requires a URL to be passed to its constructor even though it will
         # never be used; specifying the URL is a requirement for standard downloading pipeline that
@@ -71,7 +70,7 @@ class DeclarativeContentCreatorMixin:
         da = DeclarativeArtifact(
             artifact=artifact,
             url="hackathon",
-            relative_path=publication_filepath,
+            relative_path=relative_file_path,
         )
 
         return DeclarativeContent(content=content, d_artifacts=[da])

--- a/pulp_ostree/app/tasks/synchronizing.py
+++ b/pulp_ostree/app/tasks/synchronizing.py
@@ -196,14 +196,14 @@ class OstreeFirstStage(DeclarativeContentCreatorMixin, Stage):
     def create_remote_artifact_dc(self, relative_path, content):
         """Create a declarative artifact that will have associated a remote artifact with it."""
         content_url = urljoin(self.remote.url, relative_path)
-        publication_path = os.path.join(self.repo_name, relative_path)
-        content.relative_path = publication_path
+
+        content.relative_path = relative_path
 
         da = DeclarativeArtifact(
             artifact=Artifact(),
             remote=self.remote,
             url=content_url,
-            relative_path=publication_path,
+            relative_path=relative_path,
             deferred_download=self.deferred_download,
         )
 

--- a/pulp_ostree/tests/functional/api/test_import.py
+++ b/pulp_ostree/tests/functional/api/test_import.py
@@ -5,7 +5,6 @@ import subprocess
 import unittest
 
 from pathlib import Path
-from urllib.parse import urljoin
 
 from pulp_smash import config, api
 from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
@@ -114,7 +113,7 @@ class ImportCommitTestCase(unittest.TestCase):
         distribution = monitor_task(response.task).created_resources[0]
         self.addCleanup(self.distributions_api.delete, distribution)
 
-        ostree_repo_path = urljoin(self.distributions_api.read(distribution).base_url, repo_name1)
+        ostree_repo_path = self.distributions_api.read(distribution).base_url
 
         # 10. initialize a second local OSTree repository and pull the content from Pulp
         remote_name = init_local_repo_with_remote(repo_name2, ostree_repo_path)
@@ -230,9 +229,7 @@ class ImportCommitTestCase(unittest.TestCase):
         distribution = monitor_task(response.task).created_resources[0]
         self.addCleanup(self.distributions_api.delete, distribution)
 
-        ostree_repo_path = urljoin(
-            self.distributions_api.read(distribution).base_url, self.repo_name1
-        )
+        ostree_repo_path = self.distributions_api.read(distribution).base_url
 
         # 11. initialize a local OSTree repository and pull the content from Pulp
         remote_name = init_local_repo_with_remote(self.repo_name2, ostree_repo_path)

--- a/pulp_ostree/tests/functional/api/test_modify.py
+++ b/pulp_ostree/tests/functional/api/test_modify.py
@@ -1,7 +1,7 @@
 import shutil
 import unittest
 
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse
 
 from requests.exceptions import HTTPError
 
@@ -104,9 +104,7 @@ class ModifyRepositoryTestCase(unittest.TestCase):
         distribution = monitor_task(response.task).created_resources[0]
         self.addCleanup(self.distributions_api.delete, distribution)
 
-        ostree_repo_path = urljoin(
-            self.distributions_api.read(distribution).base_url, self.remote.name
-        )
+        ostree_repo_path = self.distributions_api.read(distribution).base_url
 
         remote_name = init_local_repo_with_remote(self.remote.name, ostree_repo_path)
         self.addCleanup(shutil.rmtree, self.remote.name)
@@ -151,9 +149,7 @@ class ModifyRepositoryTestCase(unittest.TestCase):
         distribution = monitor_task(response.task).created_resources[0]
         self.addCleanup(self.distributions_api.delete, distribution)
 
-        ostree_repo_path = urljoin(
-            self.distributions_api.read(distribution).base_url, self.remote.name
-        )
+        ostree_repo_path = self.distributions_api.read(distribution).base_url
 
         remote_name = init_local_repo_with_remote(self.remote.name, ostree_repo_path)
         self.addCleanup(shutil.rmtree, self.remote.name)

--- a/pulp_ostree/tests/functional/api/test_sync.py
+++ b/pulp_ostree/tests/functional/api/test_sync.py
@@ -1,8 +1,6 @@
 import shutil
 import unittest
 
-from urllib.parse import urljoin
-
 from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
 from pulp_smash.pulp3.utils import gen_repo, gen_distribution
 
@@ -92,7 +90,7 @@ class BasicSyncTestCase(unittest.TestCase):
         distribution = monitor_task(response.task).created_resources[0]
         self.addCleanup(self.distributions_api.delete, distribution)
 
-        ostree_repo_path = urljoin(self.distributions_api.read(distribution).base_url, remote.name)
+        ostree_repo_path = self.distributions_api.read(distribution).base_url
 
         # 5. initialize a local OSTree repository and pull the content from Pulp
         remote_name = init_local_repo_with_remote(remote.name, ostree_repo_path)


### PR DESCRIPTION
Content is now correctly published at the path specified by a distribution:
```
(pulp) [vagrant@pulp3-source-fedora34 devel]$ pulp ostree distribution create --name dist --base-path ostree-dir/asdf/asdf/here --repository foo
Started background task /pulp/api/v3/tasks/7f96508a-0001-4c3d-ac0c-bde7dea217a7/
.Done.
{
  "pulp_href": "/pulp/api/v3/distributions/ostree/ostree/b99be70d-95c9-4e3a-beaa-c38ac0358332/",
  "pulp_created": "2021-11-09T09:42:36.493573Z",
  "base_path": "ostree-dir/asdf/asdf/here",
  "base_url": "http://pulp3-source-fedora34.localhost.example.com/pulp/content/ostree-dir/asdf/asdf/here/",
  "content_guard": null,
  "pulp_labels": {},
  "name": "dist",
  "repository": "/pulp/api/v3/repositories/ostree/ostree/d148903b-c938-4ce3-b27c-7b37e6462515/",
  "repository_version": null
}

(pulp) [vagrant@pulp3-source-fedora34 devel]$ http http://pulp3-source-fedora34.localhost.example.com/pulp/content/ostree-dir/asdf/asdf/here/
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 463
Content-Type: text/html
Date: Tue, 09 Nov 2021 09:42:45 GMT
Server: nginx/1.20.1
X-PULP-CACHE: MISS

        <!DOCTYPE html>
        <html>
            <body>
                <ul>
                
                    <li><a href="config">config</a></li>
                
                    <li><a href="objects/">objects/</a></li>
                
                    <li><a href="refs/">refs/</a></li>
                
                    <li><a href="summary">summary</a></li>
                
                </ul>
            </body>
        </html>
```