### PR TITLE
Retrieve parent commits from child commits directly

### DIFF
--- a/CHANGES/140.feature
+++ b/CHANGES/140.feature
@@ -1,0 +1,1 @@
+The reference to a parent commit is now retrieved from a child commit automatically.

--- a/docs/workflows/import.rst
+++ b/docs/workflows/import.rst
@@ -102,7 +102,7 @@ Response::
 
 Import the uploaded file to the repository and wait until the task finishes::
 
-    http ${BASE_ADDR}${REPO_HREF}import_commits/ artifact=${COMMIT2_ARTIFACT_HREF} repository_name=repo ref=fedora/33/x86_64/iot parent_commit=50aeff7f74c66041ffc9e197887bfd5e427248ff1405e0e61e2cff4d3a1cecc7
+    http ${BASE_ADDR}${REPO_HREF}import_commits/ artifact=${COMMIT2_ARTIFACT_HREF} repository_name=repo ref=fedora/33/x86_64/iot
 
 Response::
 

--- a/pulp_ostree/app/serializers.py
+++ b/pulp_ostree/app/serializers.py
@@ -29,12 +29,6 @@ class OstreeRepoImportSerializer(serializers.Serializer):
         required=False,
         help_text=_("The name of a ref branch that holds the reference to the last commit."),
     )
-    parent_commit = serializers.CharField(
-        required=False,
-        help_text=_(
-            "The checksum of a parent commit with which the content needs to be associated."
-        ),
-    )
 
     def validate(self, data):
         """Validate the passed tarball and optional ref attributes."""
@@ -42,7 +36,6 @@ class OstreeRepoImportSerializer(serializers.Serializer):
         new_data.update(self.initial_data)
 
         self.validate_tarball(new_data)
-        self.validate_ref_and_parent_commit(new_data)
 
         return new_data
 
@@ -52,19 +45,6 @@ class OstreeRepoImportSerializer(serializers.Serializer):
         if not is_tarfile(artifact.file.path):
             raise serializers.ValidationError(_("The artifact is not a tar archive file"))
         data["artifact"] = artifact
-
-    def validate_ref_and_parent_commit(self, data):
-        """Check if a user provided a ref and parent when adding commits to a repository."""
-        ref = data.get("ref")
-        parent_commit = data.get("parent_commit")
-
-        if all([ref, parent_commit]) or not any([ref, parent_commit]):
-            data["ref"] = ref
-            data["parent_commit"] = parent_commit
-        else:
-            raise serializers.ValidationError(
-                _("Both the parent commit and ref should be specified when adding new content")
-            )
 
 
 class OstreeCommitSerializer(platform.SingleArtifactContentSerializer):

--- a/pulp_ostree/app/tasks/stages.py
+++ b/pulp_ostree/app/tasks/stages.py
@@ -52,7 +52,7 @@ class DeclarativeContentCreatorMixin:
 
     async def submit_previous_commits_and_related_objects(self):
         """Associate parent and child commits while submitting all related objects to the queue."""
-        for i in range(len(self.commit_dcs) - 1):
+        for i in reversed(range(len(self.commit_dcs) - 1)):
             self.commit_dcs[i].extra_data["parent_commit"] = self.commit_dcs[i + 1].content
 
             await self.put(self.commit_dcs[i])

--- a/pulp_ostree/app/viewsets.py
+++ b/pulp_ostree/app/viewsets.py
@@ -76,8 +76,7 @@ class OstreeRepositoryViewSet(core.RepositoryViewSet, ModifyRepositoryActionMixi
 
         artifact = serializer.validated_data["artifact"]
         repository_name = serializer.validated_data["repository_name"]
-        ref = serializer.validated_data["ref"]
-        parent_commit = serializer.validated_data["parent_commit"]
+        ref = serializer.validated_data.get("ref")
 
         async_result = dispatch(
             tasks.import_ostree_content,
@@ -87,7 +86,6 @@ class OstreeRepositoryViewSet(core.RepositoryViewSet, ModifyRepositoryActionMixi
                 "repository_pk": str(repository.pk),
                 "repository_name": repository_name,
                 "ref": ref,
-                "parent_commit": parent_commit,
             },
         )
         return core.OperationPostponedResponse(async_result, request)


### PR DESCRIPTION
In this commit, multiple bugs have been addressed - improper order of child commits while creating associations with parent commits, duplicated refs storage, and invalid parent commits traversal.

closes #140