### PR TITLE
Split import workflows into separate endpoints

### DIFF
--- a/CHANGES/170.feature
+++ b/CHANGES/170.feature
@@ -1,0 +1,3 @@
+The old endpoint for importing a whole OSTree repository, including refs, was renamed to
+``import_all``. The endpoint ``import_commits`` shall be now used to import commits to an existing
+ref.

--- a/pulp_ostree/app/serializers.py
+++ b/pulp_ostree/app/serializers.py
@@ -11,8 +11,8 @@ from pulpcore.plugin.viewsets import NamedModelViewSet
 from . import models
 
 
-class OstreeRepoImportSerializer(serializers.Serializer):
-    """A Serializer class for importing commits to a Pulp OSTree repository."""
+class OstreeImportAllSerializer(serializers.Serializer):
+    """A Serializer class for importing all refs and commits to a repository."""
 
     artifact = platform.RelatedField(
         many=False,
@@ -23,11 +23,6 @@ class OstreeRepoImportSerializer(serializers.Serializer):
     )
     repository_name = serializers.CharField(
         help_text=_("The name of a repository that contains the compressed OSTree content.")
-    )
-
-    ref = serializers.CharField(
-        required=False,
-        help_text=_("The name of a ref branch that holds the reference to the last commit."),
     )
 
     def validate(self, data):
@@ -45,6 +40,14 @@ class OstreeRepoImportSerializer(serializers.Serializer):
         if not is_tarfile(artifact.file.path):
             raise serializers.ValidationError(_("The artifact is not a tar archive file"))
         data["artifact"] = artifact
+
+
+class OstreeImportCommitsToRefSerializer(OstreeImportAllSerializer):
+    """A Serializer class for appending child commits to a repository."""
+
+    ref = serializers.CharField(
+        help_text=_("The name of a ref branch that holds the reference to the last commit."),
+    )
 
 
 class OstreeCommitSerializer(platform.SingleArtifactContentSerializer):

--- a/pulp_ostree/app/tasks/__init__.py
+++ b/pulp_ostree/app/tasks/__init__.py
@@ -1,3 +1,3 @@
 from .synchronizing import synchronize  # noqa
-from .importing import import_ostree_content  # noqa
+from .importing import import_all_refs_and_commits, import_child_commits  # noqa
 from .modifying import modify_content  # noqa

--- a/pulp_ostree/app/tasks/importing.py
+++ b/pulp_ostree/app/tasks/importing.py
@@ -30,8 +30,27 @@ gi.require_version("OSTree", "1.0")
 from gi.repository import Gio, GLib, OSTree  # noqa: E402: module level not at top of file
 
 
-def import_ostree_content(artifact_pk, repository_pk, repository_name, ref=None):
-    """Import content to an OSTree repository.
+def import_all_refs_and_commits(artifact_pk, repository_pk, repository_name):
+    """Import all ref and commits to an OSTree repository.
+
+    Args:
+        artifact_pk (str): The PK of an artifact that identifies a tarball.
+        repository_pk (str): The repository PK.
+        repository_name (str): The name of an OSTree repository (e.g., "repo").
+
+    Raises:
+        ValueError: If an OSTree repository could not be properly parsed or the specified ref
+            does not exist.
+    """
+    tarball_artifact = Artifact.objects.get(pk=artifact_pk)
+    repository = Repository.objects.get(pk=repository_pk)
+    first_stage = OstreeImportAllRefsFirstStage(tarball_artifact, repository_name)
+    dv = OstreeImportDeclarativeVersion(first_stage, repository)
+    return dv.create()
+
+
+def import_child_commits(artifact_pk, repository_pk, repository_name, ref):
+    """Import child commits to a specific ref.
 
     Args:
         artifact_pk (str): The PK of an artifact that identifies a tarball.
@@ -45,11 +64,7 @@ def import_ostree_content(artifact_pk, repository_pk, repository_name, ref=None)
     """
     tarball_artifact = Artifact.objects.get(pk=artifact_pk)
     repository = Repository.objects.get(pk=repository_pk)
-
-    if ref:
-        first_stage = OstreeImportSingleRefFirstStage(tarball_artifact, repository_name, ref)
-    else:
-        first_stage = OstreeImportAllRefsFirstStage(tarball_artifact, repository_name)
+    first_stage = OstreeImportSingleRefFirstStage(tarball_artifact, repository_name, ref)
     dv = OstreeImportDeclarativeVersion(first_stage, repository)
     return dv.create()
 

--- a/pulp_ostree/tests/functional/api/test_import.py
+++ b/pulp_ostree/tests/functional/api/test_import.py
@@ -14,7 +14,8 @@ from pulpcore.client.pulp_ostree import (
     DistributionsOstreeApi,
     OstreeOstreeRepository,
     OstreeOstreeDistribution,
-    OstreeRepoImport,
+    OstreeImportAll,
+    OstreeImportCommitsToRef,
     ContentCommitsApi,
     ContentRefsApi,
     RepositoriesOstreeApi,
@@ -95,8 +96,8 @@ class ImportCommitTestCase(unittest.TestCase):
         # 7. commit the tarball to a Pulp repository
         repo = self.repositories_api.create(OstreeOstreeRepository(**gen_repo()))
         self.addCleanup(self.repositories_api.delete, repo.pulp_href)
-        commit_data = OstreeRepoImport(artifact["pulp_href"], repo_name1)
-        response = self.repositories_api.import_commits(repo.pulp_href, commit_data)
+        commit_data = OstreeImportAll(artifact["pulp_href"], repo_name1)
+        response = self.repositories_api.import_all(repo.pulp_href, commit_data)
         repo_version = monitor_task(response.task).created_resources[0]
 
         # 8. check the number of created commits, branches (refs), and objects
@@ -193,8 +194,8 @@ class ImportCommitTestCase(unittest.TestCase):
         # 7. import the first repository
         repo = self.repositories_api.create(OstreeOstreeRepository(**gen_repo()))
         self.addCleanup(self.repositories_api.delete, repo.pulp_href)
-        commit_data = OstreeRepoImport(self.commit_repo1_artifact["pulp_href"], self.repo_name1)
-        response = self.repositories_api.import_commits(repo.pulp_href, commit_data)
+        commit_data = OstreeImportAll(self.commit_repo1_artifact["pulp_href"], self.repo_name1)
+        response = self.repositories_api.import_all(repo.pulp_href, commit_data)
         repo_version = monitor_task(response.task).created_resources[0]
 
         repository_version = self.versions_api.read(repo_version)
@@ -205,7 +206,9 @@ class ImportCommitTestCase(unittest.TestCase):
         self.assertEqual(added_content["ostree.object"]["count"], 3)
 
         # 8. import data from the second repository
-        add_data = OstreeRepoImport(self.commit_repo2_artifact["pulp_href"], self.repo_name1, "foo")
+        add_data = OstreeImportCommitsToRef(
+            self.commit_repo2_artifact["pulp_href"], self.repo_name1, "foo"
+        )
         response = self.repositories_api.import_commits(repo.pulp_href, add_data)
         repo_version = monitor_task(response.task).created_resources[0]
 


### PR DESCRIPTION
As of now, users are required to use separate endpoints for importing
content based on the actual workflow. Those who would like to import
all refs and commits into a repository should use the ``import_all``
endpoint. When the users want to append just a set of commits associated
to a specific ref, they should use the ``import_commits`` endpoint.

closes #170