### PR TITLE
Generate summary files automatically when importing a repository

### DIFF
--- a/CHANGES/269.bugfix
+++ b/CHANGES/269.bugfix
@@ -1,0 +1,1 @@
+Started re-generating summary files and publishing them during the import.

--- a/pulp_ostree/app/tasks/importing.py
+++ b/pulp_ostree/app/tasks/importing.py
@@ -18,6 +18,7 @@ from pulp_ostree.app.models import (
     OstreeCommit,
     OstreeConfig,
     OstreeObjectType,
+    OstreeSummary,
 )
 from pulp_ostree.app.tasks.utils import copy_to_local_storage, get_checksum_filepath
 from pulp_ostree.app.tasks.stages import OstreeAssociateContent, DeclarativeContentCreatorMixin
@@ -267,6 +268,9 @@ class OstreeImportSingleRefFirstStage(
 
             await self.submit_ref_objects()
 
+            self.repo.regenerate_summary()
+            await self.submit_metafile_object("summary", OstreeSummary())
+
 
 class OstreeImportAllRefsFirstStage(
     DeclarativeContentCreatorMixin, OstreeSingleRefParserMixin, OstreeImportStage
@@ -321,6 +325,9 @@ class OstreeImportAllRefsFirstStage(
                 await pb.aincrement()
 
             await self.submit_ref_objects()
+
+            self.repo.regenerate_summary()
+            await self.submit_metafile_object("summary", OstreeSummary())
 
 
 class OstreeImportDeclarativeVersion(DeclarativeVersion):


### PR DESCRIPTION
~- [ ] Generate a summary file when modifying the repository (consider generating the summary before finalizing every new repository version)~
~- [ ] Add a test case~
~- [ ] Document flatpak support~

closes #269