### PR TITLE
Use a customized version of QueryExistingArtifacts

### DIFF
--- a/CHANGES/289.bugfix
+++ b/CHANGES/289.bugfix
@@ -1,0 +1,1 @@
+Improved the performance of subsequent imports.


### PR DESCRIPTION
In this change, the stage is comparing only sha256 digests between existing and newly added artifacts. Furthermore, the time complexity for the old comparison was O(N^2). With the change, we work with O(2N).

closes #289