### PR TITLE
Pin pytest version to avoid CI permission errors

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,2 +1,2 @@
 pulp-smash @ git+https://github.com/pulp/pulp-smash.git
-pytest
+pytest==7.4.4


### PR DESCRIPTION
The CI is failing with `pytest-8.0.0`:
```
E   PermissionError: [Errno 13] Permission denied: '/lost+found/__init__.py'
```
[noissue]